### PR TITLE
plaid-accounts: change the type of `limit` field to `number`

### DIFF
--- a/plaid-accounts/plaid-accounts-object.md
+++ b/plaid-accounts/plaid-accounts-object.md
@@ -146,7 +146,7 @@
       <td style="text-align:left"><b>limit</b>
       </td>
       <td style="text-align:left"></td>
-      <td style="text-align:left">string</td>
+      <td style="text-align:left">number</td>
       <td style="text-align:left"></td>
       <td style="text-align:left">Credit limit of the account. This field is set by Plaid and cannot be
         altered</td>


### PR DESCRIPTION
The second object in the example response of the "Get all Plaid accounts" endpoint (plaid-accounts/get-all-plaid-accounts.md) has a numeric value of 15000 in the `limit` field. This change makes the description of the object consistent with the example.