### PR TITLE
Update PlaidAccount documentation to reflect optional `limit`

### DIFF
--- a/plaid-accounts/plaid-accounts-object.md
+++ b/plaid-accounts/plaid-accounts-object.md
@@ -148,7 +148,7 @@
       <td style="text-align:left"></td>
       <td style="text-align:left">number</td>
       <td style="text-align:left"></td>
-      <td style="text-align:left">Credit limit of the account. This field is set by Plaid and cannot be
+      <td style="text-align:left">Optional credit limit of the account. This field is set by Plaid and cannot be
         altered</td>
     </tr>
   </tbody>


### PR DESCRIPTION
## What is this
[`GET /plaid_accounts`](https://developers.lunchmoney.app/plaid-accounts/get-all-plaid-accounts) may return `nil` for `limit`. However, the [documentation](https://developers.lunchmoney.app/plaid-accounts/plaid-accounts-object) does not include the word 'Optional' like it does for other optional fields, such as `subtype`.

![image](https://user-images.githubusercontent.com/5385681/86570958-bb54dd00-bf3e-11ea-89e9-8159edc561d7.png)

## What did I do
Added the word `Optional` to the documentation

![image](https://user-images.githubusercontent.com/5385681/86603540-1d7b0580-bf72-11ea-97c0-4b9bacff003f.png)
