### PR TITLE
include ISO format of transaction currency code

### DIFF
--- a/plaid-accounts/plaid-accounts-object.md
+++ b/plaid-accounts/plaid-accounts-object.md
@@ -130,7 +130,7 @@
       <td style="text-align:left"></td>
       <td style="text-align:left">string</td>
       <td style="text-align:left"></td>
-      <td style="text-align:left">Currency of account balance. This field is set by Plaid and cannot be
+      <td style="text-align:left">Currency of account balance in ISO 4217 format. This field is set by Plaid and cannot be
         altered</td>
     </tr>
     <tr>

--- a/recurring-expenses/recurring-expenses-object.md
+++ b/recurring-expenses/recurring-expenses-object.md
@@ -91,7 +91,7 @@
       <td style="text-align:left"></td>
       <td style="text-align:left">string</td>
       <td style="text-align:left"></td>
-      <td style="text-align:left">Three-letter lowercase currency code for the recurring expense</td>
+      <td style="text-align:left">Three-letter lowercase currency code for the recurring expense in ISO 4217 format</td>
     </tr>
     <tr>
       <td style="text-align:left"><b>description</b>

--- a/transactions/insert-transactions.md
+++ b/transactions/insert-transactions.md
@@ -127,7 +127,7 @@ An array of errors will be returned denoting reason why parameters were deemed i
       <td style="text-align:left"></td>
       <td style="text-align:left">string</td>
       <td style="text-align:left"></td>
-      <td style="text-align:left">Three-letter lowercase currency code must exist in our database. Defaults
+      <td style="text-align:left">Three-letter lowercase currency code in ISO 4217 format. The code sent must exist in our database. Defaults
         to user account&apos;s primary currency.</td>
     </tr>
     <tr>

--- a/transactions/transaction-object.md
+++ b/transactions/transaction-object.md
@@ -56,7 +56,7 @@
       <td style="text-align:left"></td>
       <td style="text-align:left">string</td>
       <td style="text-align:left"></td>
-      <td style="text-align:left">Three-letter lowercase currency code of the transaction</td>
+      <td style="text-align:left">Three-letter lowercase currency code of the transaction in ISO 4217 format</td>
     </tr>
     <tr>
       <td style="text-align:left"><b>notes</b>


### PR DESCRIPTION
Current description does not define the ISO standard. I assume it is ISO 4217 https://en.wikipedia.org/wiki/ISO_4217 .
If it is not, then I can adjust the text. 